### PR TITLE
Removes branding and text change to header topbar

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,5 @@
 <header>
   <div class="wrapper">
-    <a id="govau-logo" href="/"> GOV.AU</a>
-    <div id="star"></div>
-    <p>Content Design Guide v1.0</p>
+    <p>Content Guide v1.0</p>
   </div>
 </header>


### PR DESCRIPTION
https://github.com/AusDTO/gov-au-design-guide/commit/f1b46cac94965ab3962bc66f19cfc1ddff47901e reflects the upstream design CSS change that coincides with this.
