### PR TITLE
Rename app to match repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Content guidelines for GOV.AU
 
 It is very much a **work-in-progress** and not ready for general use.
 
-It can be accessed at http://content-style-guide.apps.staging.digital.gov.au/
+It can be accessed at http://gov-au-content-guide.apps.staging.digital.gov.au/
 
 This will remain **password protected** until the content guide is ready for general release.
 

--- a/bin/cideploy.sh
+++ b/bin/cideploy.sh
@@ -5,4 +5,4 @@ set -e
 # Output the commands we run
 set -x
 
-cf push content-style-guide -b staticfile_buildpack -p ./_site -i 1
+cf push gov-au-content-guide -b staticfile_buildpack -p ./_site -i 1


### PR DESCRIPTION
This renames the app to match the github name for consistency sake

Before the PR is merged:
- [ ] Let everyone know who is working on the content guide that the app url is about to change

After this PR is merged:
- [ ] Change the urls in any Trello tickets
- [ ] Update the url of the project in the github description
- [ ] Ask @m-richo nicely to delete the old app at http://content-style-guide.apps.staging.digital.gov.au/
