### PR TITLE
Adding 3 missing tier-3 sub items to the Writing for the Web section.

### DIFF
--- a/guides/_posts/2016-05-05-structure-your-page-for-readability.md
+++ b/guides/_posts/2016-05-05-structure-your-page-for-readability.md
@@ -1,0 +1,69 @@
+---
+title: "Structure your page for readability"
+abstract: "Sectioning your content"
+layout: guide-page
+---
+
+People will hesitate to read web pages that are difficult to scan. Structure your content to lead the user through the web page, always choosing the shorter, word, sentence and paragraph over the longer.
+
+## Identify the aim
+
+Identify the aim of your content to know the level of detail you need. Focus on how the user should do something, rather than telling them about something. Make calls to action clear and simple.
+
+## Use headings and subheadings
+
+Headings are signposts in text and navigational aids. Readers use headings to scan content and to gauge the relationship between and importance of sections of text.
+
+When designing the flow of information on a web page structure your content with hierarchical headers (H1, H2, H3, H4). Use meaningful text and keywords in headers and links
+
+### Headings & subheadings
+
+#### Limit levels
+
+Content should only have 1 top level (H1) heading. Be careful with the number of headings added beyond this. Readers will lose track if there are too many heading levels. Short content should only use 2 extra subheading levels (H2 and H3).
+
+#### Use space
+
+To aid readability and comprehension, use headings to break up text and draw in the reader.
+
+To support both navigation and access, use a heading at least every 100 words or so (every 2 to 3 paragraphs).
+
+#### Be interesting
+
+Make headings specific enough to catch the reader’s attention. You should either provide information or raise a query.
+
+Avoid meaningless words for headings such as general, miscellaneous, other, or more.
+
+#### Keep it short
+
+Try to limit headings to less than 1 line. Headings that spill over to a second line are harder to read and to recall.
+
+#### Chunk in paragraphs
+
+A paragraph is a section of text that contains a single idea.
+
+State your idea in the first sentence. This will attract your reader’s attention and get your message across.
+
+Readers often scan headings and first sentences of paragraphs as they search for the information they want.
+
+#### Vary length
+
+Structure your paragraphs so they range in length from 2 to 3 sentences.
+
+If appropriate to the content, vary the length of paragraph to provide variety. This makes content more interesting and readable.
+
+#### Use simple sentences
+
+Use short sentences that contain a single message. If you need to communicate other messages use a second sentence, commas or brackets.
+
+Vary the length of your sentences to make content less tiring to read. For many people comprehension can start to fail after 25 to 30 words, so this should be the limit of your longest sentences.
+
+#### Break up content with lists
+
+If you have long sentences with many elements, use a list to break up the text and make it easier for your reader to understand and scan.
+
+Use bullet lists by default. You should only use numbers or letters when it is necessary to show a priority order or chronology.
+
+***
+
+Link: `Lists`

--- a/guides/_posts/2016-05-05-thing-like-a-govau-content-designer.md
+++ b/guides/_posts/2016-05-05-thing-like-a-govau-content-designer.md
@@ -1,0 +1,39 @@
+---
+title: "Think like a GOV.AU content designer"
+abstract: "Modern content authoring"
+layout: guide-page
+---
+
+Broadly speaking, a GOV.AU content designer is a writer and editor who understands the web and its users. We not only craft great content, we also work across a multi-disciplinary team to create purposeful services and gain an in-depth knowledge of a wide range of subjects across government.
+
+A content designer at GOV.AU analyses every piece of content based on what the user needs to know, rather than what government wants to say.
+
+Good content designers can pivot quickly as a project’s scope changes (a natural part of any creative process), innovate, initiate and anticipate. We are sticklers for high quality, we understand readability, usability and accessibility, and we know that plain English always wins.
+
+## It’s not just writing or editing
+
+Traditionally, content people play a role where we ‘fix the content often towards the end of a project’. Typically we take existing content created by someone else and shape it, or we generate words from scratch based on research.
+
+But content design goes deeper than that. In this role we get to really be part of the thinking around:
+
+* **What** information will be created (not always just words)
+* **Why** will it be created
+* **How** it will look once it’s laid out.
+
+Our writing and editing skills are still critical in making the language clearer and simpler (and play a strong role in the many rounds of iterating that are part of each project) but our overall job is to be a crucial part of the movement to help change and shift perceptions of how government is perceived. We do this by making the information simpler, clearer and faster. This is a team effort.
+
+## Embrace the Discovery (research) phase
+
+The creation of good content ideally begins at [Discovery](https://www.dto.gov.au/standard/service-design-and-delivery-process/discovery/) at the very first user research session where the content designer takes on the role of observer. The insights gained from listening and reflecting on what real people say, think and do in relation to the topic/s that you will end up researching and writing about, is invaluable.
+
+This chance to participate gives you the language, the different perspectives and an understanding of the pain points that naturally get reflected back into the voice and style of the content you help create.
+
+It also helps you get across the decisions that will be made about the information you’ll eventually help generate. If you come in later to a project where the Discovery phase has already started, it’s essential to go back over the research archives and have conversations with the service designers and other content designers who were at the initial sessions.
+
+## Get used to working closely with others
+
+At GOV.AU no-one works in a silo, including content designers. The experience is highly collaborative across the whole team.
+
+This is fantastic in that content people get to be part of the conversation and decision-making. It gives you a chance to gain insights about the subject from various angles, which means we are better in tune with what the end-state might be.
+
+And when it comes to the final stages of editing there is more efficiency and co-operation around our changes because we have been part of the conversations and ensuring consensus along the way.

--- a/guides/_posts/2016-05-05-write-in-plain-english.md
+++ b/guides/_posts/2016-05-05-write-in-plain-english.md
@@ -1,0 +1,57 @@
+---
+title: "Write in plain English"
+abstract: "Simplifying writing for native and non-native readers alike"
+layout: guide-page
+---
+
+The rule is to make language as simple as your users need it to be. Generally this should be plain English so it can be understood by everyone, regardless of ability.
+
+Follow these points to create plain English content:
+
+## Use an active voice
+
+Active voice clearly identifies who is doing what to whom, is more immediate and generally uses fewer words.
+
+For example:
+
+> The director approved the proposal for the new part-time role.
+
+Passive voice sounds evasive and sends the reader backwards.
+
+For example:
+
+> The proposal for the new part-time role was approved by the director.
+
+Passive is acceptable where there is no do-er.
+
+For example:
+
+> The proposal for the new-part time role was approved in March.
+
+## Personalise the language
+
+Use first and second pronouns (‘I’, ‘we’, ‘us’ and ‘you’) to establish a connection with users.
+
+Use ‘they’ when talking about, rather than to someone or something.
+
+For example:
+
+> The department is launching its website when they are ready to go live.
+
+## Use fewer words
+
+Check your content and remove unnecessary words, sentences and paragraphs. 1 idea per paragraph makes information easier to follow.
+
+## Minimise punctuation
+
+It’s easier to read several short sentences than a long sentence broken up with punctuation.
+
+## Don’t use jargon or ‘fancy’ language
+
+Write as your users talk rather than how government speaks internally. Keep it conversational for easier comprehension.
+
+## Think of people who don’t use English as a first language
+
+Read back what you’ve written to check that it could be understood by someone who speaks English as a second, third, fourth etc language.
+
+Consider whether the information should also be provided in appropriate community language—a good idea if there are compliance requirements.


### PR DESCRIPTION
Just adds the 3 missing pieces of content under the Writing for the Web section.

Things to note:
- i’ve added abstracts for the items (not noted in the gdocs)
- i have reformatted some of the content (difficult to add multi-paragraph list items)

Some content may still need reformatting, namely pulling things out of unsorted lists and instead putting them under either/or headings, definition lists, ….

Example text should also probably be turned into blockquotes.
