### PR TITLE
Fixes az-index sidebar nav entry title casing, and …

### DIFF
--- a/_entries/2016-05-04-aboriginal-and-torres-strait-islander-peoples.md
+++ b/_entries/2016-05-04-aboriginal-and-torres-strait-islander-peoples.md
@@ -1,5 +1,5 @@
 ---
-title: "Aboriginal and Torres Strait Islander peoples"
+title: "Aboriginal & Torres Strait Islander peoples"
 related: [inclusivity]
 ---
 

--- a/_entries/2016-05-04-colons-and-semicolons.md
+++ b/_entries/2016-05-04-colons-and-semicolons.md
@@ -1,5 +1,5 @@
 ---
-title: "Colons and semicolons"
+title: "Colons & semicolons"
 related: [lists, punctuation]
 ---
 

--- a/_entries/2016-05-04-dates-and-time-periods.md
+++ b/_entries/2016-05-04-dates-and-time-periods.md
@@ -1,5 +1,5 @@
 ---
-title: "Dates and time periods"
+title: "Dates & time periods"
 related: [time]
 ---
 

--- a/_entries/2016-05-04-dictionaries-spell-checkers.md
+++ b/_entries/2016-05-04-dictionaries-spell-checkers.md
@@ -1,5 +1,5 @@
 ---
-title: "Dictionaries and spell checkers"
+title: "Dictionaries & spell checkers"
 related: [government-naming-conventions, spelling]
 ---
 

--- a/_entries/2016-05-04-hyphens-and-dashes.md
+++ b/_entries/2016-05-04-hyphens-and-dashes.md
@@ -1,5 +1,5 @@
 ---
-title: "Hyphens and dashes"
+title: "Hyphens & dashes"
 related: [em-dashes]
 ---
 

--- a/_entries/2016-05-04-inclusivity-diversity.md
+++ b/_entries/2016-05-04-inclusivity-diversity.md
@@ -1,6 +1,6 @@
 ---
-title: "Inclusivity and diversity"
-related: [aboriginal-torres-strait-islander-people, accessibility, languages, tone, voice]
+title: "Inclusivity & diversity"
+related: [aboriginal-and-torres-strait-islander-peoples, accessibility, languages, tone, voice]
 ---
 
 When preparing content for people who have come to Australia from non-English speaking countries, you should recognise cultural diversity and specific needs -- while not stereotyping or making assumptions.

--- a/_includes/sidebar-nav-az.html
+++ b/_includes/sidebar-nav-az.html
@@ -29,7 +29,7 @@
 
         <a href="#{{ entry.path | entry_file }}">
           <li class="nav-item">
-            {{ entry.path | entry_heading }}
+            {{ entry.title }}
           </li>
         </a>
 


### PR DESCRIPTION
… unifies entry titles to use '&' instead of 'and'.
