### PR TITLE
Adds downcase filter for A-Z URL sidebar nav to fix anchors.

### DIFF
--- a/_includes/sidebar-nav-az.html
+++ b/_includes/sidebar-nav-az.html
@@ -16,7 +16,7 @@
     </ul>
     {% endif %}
 
-    <a href="/az-indexes/{{ letter }}.html">
+    <a href="/az-indexes/{{ letter | downcase }}.html">
       <li class="nav-item">
         {{ letter }}
       </li>
@@ -27,7 +27,7 @@
       {% assign prev_letter = letter %}
     {% endif %}{% comment %} closes if letter != prev_letter {% endcomment %}
 
-        <a href="{{ site.baseurl }}{{ letter }}.html#{{ entry.path | entry_file }}">
+        <a href="{{ site.baseurl }}{{ letter | downcase }}.html#{{ entry.path | entry_file }}">
           <li class="nav-item">
             {{ entry.path | entry_heading }}
           </li>


### PR DESCRIPTION
Staging anchors for the A-Z section was case-sensitive, and our $letter.md files are lowercase, so the links were broken on staging.
