### PR TITLE
Remove extra space in measurement examples

### DIFF
--- a/_entries/2016-05-04-abbreviations-and-acronyms.md
+++ b/_entries/2016-05-04-abbreviations-and-acronyms.md
@@ -15,7 +15,7 @@ Abbreviate kilograms, kilojoules, kilometres, kilowatts when using numbers.
 
 **For example**
 
-> 6 kg, 6 kJ, 6 km/h (not 6 kph), 6 kW
+> 6kg, 6kJ, 6km/h (not 6kph), 6kW
 
 Do not use punctuation for eg ie and etc.
 

--- a/_entries/2016-05-04-dates-and-time-periods.md
+++ b/_entries/2016-05-04-dates-and-time-periods.md
@@ -1,6 +1,6 @@
 ---
 title: "Dates & time periods"
-related: 
+related:
   - time
 published: true
 ---
@@ -11,7 +11,7 @@ No punctuation is used for dates.
 
 > On Tuesday 8 October 2016. Not 8th October, 2016.
 
-Time periods: use numbers. 
+Time periods: use numbers.
 
 **For example**
 
@@ -21,8 +21,8 @@ To indicate spans of time, use from ... to ... or dashes. From ... to ... is eas
 
 **For example**
 
-> - from 10 to 12 October or 10–12 October
-> - from 10 am to 11 am or 10 am–11 am.
+> - from 10 to 12 October, or 10–12 October
+> - from 10am to 11am, or 10am–11am.
 
 Use numbers at the beginning of a line, bulleted item or sentence.
 

--- a/_entries/2016-05-04-hyphens-and-dashes.md
+++ b/_entries/2016-05-04-hyphens-and-dashes.md
@@ -24,7 +24,7 @@ Use em dashes without a space on either side (---) when adding an idea to a sent
 > 27% of Australians were born overseas---another 2.5% identify as being Aboriginal and Torres Strait Islander peoples.
 
 - In Microsoft Word: hold down the <kbd>Alt</kbd> key, type <kbd>0151</kbd> on the numeric keypad and then release the <kbd>Alt</kbd> key
-- On Mac: Hold <kbd>Option</kbd> + <kbd>Shift</kbd> keys and type <kbd>-</kbd> 
+- On Mac: Hold <kbd>Option</kbd> + <kbd>Shift</kbd> keys and type <kbd>-</kbd>
 - In [kramdown Markdown](http://kramdown.gettalong.org/) notation: use 3 hyphens (<kbd>---</kbd>)
 - Google Docs: go to Insert then Special characters.
 
@@ -36,5 +36,5 @@ To indicate spans of time or page numbers etc use the word 'to' or 'from' prefer
 
 **For example**
 
-> - from page 64 to 78 or page 64-78 
-- from 10 am to 11 am or 10 am-11 am.
+> - from page 64 to 78 or page 64-78
+> - from 10am to 11am or 10am-11am.

--- a/_entries/2016-05-04-weights-and-measures.md
+++ b/_entries/2016-05-04-weights-and-measures.md
@@ -1,6 +1,6 @@
 ---
 title: "Weights & measures"
-related: 
+related:
   - "abbreviations-and-acronyms"
 published: true
 ---
@@ -15,6 +15,6 @@ Abbreviate when using a number and allow a space between
 
 **For example**
 
-> 6 cm, 6 kg, 6 kJ, 6 km/h and 6 kW.
+> 6cm, 6kg, 6kJ, 6km/h and 6kW.
 
 Abbreviate in headings, tables and graphics, with or without a number. Use the percentage sign with a number, eg 3%, otherwise use per cent not percent.


### PR DESCRIPTION
Requested by @libbyv for consistency. Thanks for spotting trisha