### PR TITLE
Add 'sentence case' // fix examples

### DIFF
--- a/_entries/2016-05-04-capitalisation.md
+++ b/_entries/2016-05-04-capitalisation.md
@@ -8,6 +8,12 @@ published: true
 
 Capital letters are hard to read. Keep them to a minimum.
 
+Use sentence case for most things. Use title case for proper nouns.
+
+**For example**
+
+> The city is in south-east New South Wales.
+
 ### When to use capital letters
 
 #### First letter in headings and subheadings
@@ -38,17 +44,10 @@ Capital letters are hard to read. Keep them to a minimum.
 
 **For example**
 
-> the Government Information Public Access Act, then the Act
+> - the Government Information Public Access Act, then the Act
+> - Read Steps to Enter Residential Aged Care before our workshop.
 
-> Read Steps to Enter Residential Aged Care before our workshop.
-
-#### Places that are descriptive
-
-**For example**
-
-> south-east NSW
-
-**Further examples**
+### More examples
 
 > - the internet, not the Internet
 > - the web, not the Web or World Wide Web

--- a/_updates/index.md
+++ b/_updates/index.md
@@ -6,6 +6,13 @@ abstract: Recent changes to this guide.
 published: true
 ---
 
+## October 2016
+
+### [Capitalisation](/az-indexes/c.html#capitalisation)
+Added 'Use sentence case for most things. Use title case for proper nouns.' Also removed heading. ([185](https://github.com/AusDTO/gov-au-content-guide/pull/185))
+
+**Why?** Clarify guidance and fix proofing error
+
 ## September 2016
 
 ### [Accessibility](/az-indexes/a.html#accessibility), [mobiles](/az-indexes/m.html#mobiles) & [numbered lists](/az-indexes/n.html#numbered-lists)


### PR DESCRIPTION
## Description

- Adds content about sentence and title case.
- Fixes structure of examples.
- Resolves #133 

## Additional information

Removing the `places that are descriptive` section but retaining the
example, as it is currently incorrect; we don’t use capitals for the
`descriptive` bit.

## Definition of Done

- [x] PR approved by Libby
- [ ] Related [GitHub issues](https://waffle.io/AusDTO/gov-au-content-guide) closed
- [x] Update to [Updates page](http://content-style-guide.apps.staging.digital.gov.au/updates/)

