### PR TITLE
Remove `www`

### DIFF
--- a/_entries/2016-05-04-hyperlinks.md
+++ b/_entries/2016-05-04-hyperlinks.md
@@ -39,9 +39,9 @@ Don’t use meaningless terms such as ‘click here’, ‘read more’ or ‘us
 
 You don't need to write `http://` or `https://` when referencing a website.
 
-If the site's actual URL doesn't use `www` you don't need to write it when you reference it. Many 
+If the site has a URL route without `www` you don't need to write it when you reference it. But keep the `www` if there is only a redirect in place.
 
-You need to use the full URL when you create a hyperlink.
+You still need to use the full URL when you create a hyperlink.
 
 **For example**
 

--- a/_entries/2016-05-04-hyperlinks.md
+++ b/_entries/2016-05-04-hyperlinks.md
@@ -35,13 +35,13 @@ Not this
 
 Don’t use meaningless terms such as ‘click here’, ‘read more’ or ‘useful links’.
 
-### Drop the http://
+### Drop the http://www
 
-When referencing a website, drop the `http://` prefix.
+When referencing a website, drop the `http://www` prefix.
 
 **For example**
 
-> The Digital Transformation Office’s website is [www.dto.gov.au](https://www.dto.gov.au/).
+> The Digital Transformation Office’s website is [dto.gov.au](https://www.dto.gov.au/).
 
 Include a hyperlink with any emails, without including the `mailto:` prefix.
 

--- a/_entries/2016-05-04-hyperlinks.md
+++ b/_entries/2016-05-04-hyperlinks.md
@@ -35,15 +35,17 @@ Not this
 
 Don’t use meaningless terms such as ‘click here’, ‘read more’ or ‘useful links’.
 
-### Drop the http://www
+### Drop the https://
 
-When referencing a website, drop the `http://www` prefix. Verify the website doesn't need `www` to reach it.
+You don't need to write `http://` or `https://` when referencing a website.
 
-Use the full URL when you create a hyperlink.
+If the site's actual URL doesn't use `www` you don't need to write it when you reference it. Many 
+
+You need to use the full URL when you create a hyperlink.
 
 **For example**
 
-> The Digital Transformation Agency’s website is [dta.gov.au](https://www.dta.gov.au/).
+> The Digital Transformation Agency’s website is [www.dta.gov.au](https://www.dta.gov.au/).
 
 Include a hyperlink with any emails, without including the `mailto:` prefix.
 

--- a/_entries/2016-05-04-hyperlinks.md
+++ b/_entries/2016-05-04-hyperlinks.md
@@ -37,14 +37,16 @@ Don’t use meaningless terms such as ‘click here’, ‘read more’ or ‘us
 
 ### Drop the http://www
 
-When referencing a website, drop the `http://www` prefix.
+When referencing a website, drop the `http://www` prefix. Verify the website doesn't need `www` to reach it.
+
+Use the full URL when you create a hyperlink.
 
 **For example**
 
-> The Digital Transformation Office’s website is [dto.gov.au](https://www.dto.gov.au/).
+> The Digital Transformation Agency’s website is [dta.gov.au](https://www.dta.gov.au/).
 
 Include a hyperlink with any emails, without including the `mailto:` prefix.
 
 **For example**
 
-> [belinda.blogs@dto.gov.au](mailto:belinda.blogs@dto.gov.au), not [email Belinda, Head of Social Media](mailto:belinda.blogs@dto.gov.au).
+> [belinda.blogs@dto.gov.au](mailto:belinda.blogs@dta.gov.au), not [email Belinda, Head of Social Media](mailto:belinda.blogs@dta.gov.au).

--- a/_updates/index.md
+++ b/_updates/index.md
@@ -10,9 +10,17 @@ published: true
 
 ### [Hyperlinks](/az-indexes/h.html#hyperlinks)
 
-**Changed** 'Drop the http://' to 'Drop the http://www' ([204](https://github.com/AusDTO/gov-au-content-guide/pull/204)).
+**Changed** 'Drop the http://' to 'Drop the http://www'.
 
-**Why?** Following contemporary practice
+**Added**:
+
+> Verify the website doesn’t need `www` to reach it.
+>
+> Use the full URL when you create a hyperlink.
+
+([204](https://github.com/AusDTO/gov-au-content-guide/pull/204))
+
+**Why?** Following contemporary practice and enhancing guidance
 
 ### [Apostrophe](/az-indexes/a.html#apostrophe)
 

--- a/_updates/index.md
+++ b/_updates/index.md
@@ -8,6 +8,12 @@ published: true
 
 ## October 2016
 
+### [Hyperlinks](/az-indexes/h.html#hyperlinks)
+
+**Changed** 'Drop the http://' to 'Drop the http://www' ([204](https://github.com/AusDTO/gov-au-content-guide/pull/204)).
+
+**Why?** Following contemporary practice
+
 ### [Apostrophe](/az-indexes/a.html#apostrophe)
 
 **Added**: correct example heading ([195](https://github.com/AusDTO/gov-au-content-guide/pull/195/)).


### PR DESCRIPTION
## Description

Removes guidance about using `www` in writing web addresses.
## Additional information
- Not ready to merge
- Will close #162 
## Definition of Done
- [ ] Draft reviewed by other Content Designer
- [ ] Update to [Updates page](http://content-style-guide.apps.staging.digital.gov.au/updates/)
- [ ] PR approved by Libby
- [ ] Related [GitHub issues](https://waffle.io/AusDTO/gov-au-content-guide) closed