### PR TITLE
Change DTO to DTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ If you still have troubles contact a dev!
 
 ## Copyright & License
 
-Copyright Digital Transformation Office. Licensed under the Creative Commons Attribution 4.0 International Public License. See [LICENSE file](https://github.com/AusDTO/gov-au-content-guide/blob/master/LICENSE) for more details.
+Copyright Digital Transformation Agency. Licensed under the Creative Commons Attribution 4.0 International Public License. See [LICENSE file](https://github.com/AusDTO/gov-au-content-guide/blob/master/LICENSE) for more details.
 
-## About the DTO
+## About the DTA
 
-![](https://www.dto.gov.au/images/govt-crest.png "Australian Government crest and Digital Transformation Office title")
+![](https://www.dta.gov.au/images/logo_dta_inline.png "Australian Government crest and Digital Transformation Agency title")
 
-The GOV.AU Content Guide is maintained and funded by the [Digital Transformation Office](https://www.dto.gov.au/).
+The GOV.AU Content Guide is maintained and funded by the [Digital Transformation Agency](https://www.dta.gov.au/).

--- a/_entries/2016-05-04-abbreviations-and-acronyms.md
+++ b/_entries/2016-05-04-abbreviations-and-acronyms.md
@@ -48,7 +48,7 @@ Don’t use an acronym unless the full name has already been said once.
 
 **For example**
 
-> Digital Transformation Office (DTO).
+> Digital Transformation Agency (DTA).
 
 If an acronym is well known to an Australian audience, such as NSW or ABC, there is no need to spell it out. If you are writing for an international audience spell it out once and then use the acronym.
 

--- a/_entries/2016-05-04-hyperlinks.md
+++ b/_entries/2016-05-04-hyperlinks.md
@@ -41,10 +41,10 @@ When referencing a website, drop the `http://` prefix.
 
 **For example**
 
-> The Digital Transformation Office’s website is [www.dto.gov.au](https://www.dto.gov.au/).
+> The Digital Transformation Agency’s website is [www.dta.gov.au](https://www.dta.gov.au/).
 
 Include a hyperlink with any emails, without including the `mailto:` prefix.
 
 **For example**
 
-> [belinda.blogs@dto.gov.au](mailto:belinda.blogs@dto.gov.au), not [email Belinda, Head of Social Media](mailto:belinda.blogs@dto.gov.au).
+> [belinda.blogs@dta.gov.au](mailto:belinda.blogs@dta.gov.au), not [email Belinda, Head of Social Media](mailto:belinda.blogs@dta.gov.au).

--- a/_entries/2016-05-04-inclusivity-diversity.md
+++ b/_entries/2016-05-04-inclusivity-diversity.md
@@ -43,7 +43,7 @@ Speak to the person (in plain English, without jargon) rather than speaking to t
 
 **Resources**
 
-- [DTO Design guides --- Inclusive services](https://www.dto.gov.au/standard/design-guides/inclusive-services/)
+- [DTA Design guides --- Inclusive services](https://www.dta.gov.au/standard/design-guides/inclusive-services/)
 - [Australian Network On Disability --- Inclusive Language](http://www.and.org.au/pages/inclusive-language.html)
 - [People with disability --- Guide to Reporting Disability](http://pwd.org.au/library/guide-to-reporting-disability.html)
 - [Arts Access Australia --- Advice on Disability Language](http://www.artsaccessaustralia.org/resources/advice-sheets/63-aaa-advice-on-disability-language)

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -16,14 +16,14 @@
         <li><a href="https://groups.google.com/a/digital.gov.au/forum/#!forum/content-design-in-government">Join community</a></li>
       </ul>
       <ul>
-        <li><h3><abbr title="Digital Transformation Office">DTO</abbr></h3></li>
-        <li><a href="http://www.dto.gov.au">About the <abbr title="Digital Transformation Office">DTO</abbr></a></li>
+        <li><h3><abbr title="Digital Transformation Agency">DTA</abbr></h3></li>
+        <li><a href="http://www.dta.gov.au">About the <abbr title="Digital Transformation Agency">DTA</abbr></a></li>
         <!--<li class="nav-link back-up">[ <a href="#content-top">back to top &uarr;</a> ]</li>-->
       </ul>
     </nav>
   </div>
 
-  <p class="copyright authorship">&copy; Copyright Digital Transformation Office.</p>
+  <p class="copyright authorship">&copy; Copyright Digital Transformation Agency.</p>
   <p class="license">Licensed under the <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International license</a>.
 </footer>
 

--- a/_sources/index.md
+++ b/_sources/index.md
@@ -4,7 +4,7 @@ title: Sources and resources
 collection-title: Sources
 abstract: >-
   a list of the sources and resources used in the making of the GOV.AU Draft
-  Content Style Guide v1.0 created by the Digital Transformation Office.
+  Content Style Guide v1.0 created by the Digital Transformation Agency.
 published: true
 ---
 
@@ -12,7 +12,7 @@ published: true
 
 We have been closely guided by the GOV.UK [Government Digital Service (GDS) Style guide](https://www.gov.uk/guidance/style-guide) and [blog](https://gds.blog.gov.uk/).
 
-We’ve used content from the Department of Communications and the Arts Online Style Guide with their permission (recently updated in March 2016) and from the [DTO's Digital Service Standard Design guides](https://www.dto.gov.au/standard/design-guides/).
+We’ve used content from the Department of Communications and the Arts Online Style Guide with their permission (recently updated in March 2016) and from the [DTA's Digital Service Standard Design guides](https://www.dta.gov.au/standard/design-guides/).
 
 We have referred to respected resources including the 18F.gsa.gov [18F Content Guide](https://pages.18f.gov/content-guide/), [The Guardian and Observer style guide](https://www.theguardian.com/info/series/guardian-and-observer-style-guide), the [Macquarie Dictionary](https://www.macquariedictionary.com.au/) and the [Department of Finance's Good practice publishing for Australian Government entities](https://www.finance.gov.au/publications/good-practice-publishing/).
 
@@ -36,15 +36,15 @@ The Draft Content Style Guide v1.0 has also been guided by these resources:
 - [Guide to Reporting Disability](http://www.pwd.org.au/library/guide-to-reporting-disability.html), People with Disability
 - [How Users Read on the Web](https://www.nngroup.com/articles/how-users-read-on-the-web/), Nielsen Norman Group
 - [Inclusive language](http://www.and.org.au/pages/inclusive-language.html), Australian Network on Disability
-- [Inclusive services](https://www.dto.gov.au/standard/design-guides/inclusive-services/), Design guides, Digital Service Standard, Digital Transformation Office
+- [Inclusive services](https://www.dta.gov.au/standard/design-guides/inclusive-services/), Design guides, Digital Service Standard, Digital Transformation Agency
 - [Macquarie Dictionary](https://www.macquariedictionary.com.au/), Macquarie Dictionary Online, Macmillan Publishers Group Australia, 2015
-- [Making content accessible](https://www.dto.gov.au/standard/design-guides/making-content-accessible/), Design guides, Digital Service Standard, Digital Transformation Office
+- [Making content accessible](https://www.dta.gov.au/standard/design-guides/making-content-accessible/), Design guides, Digital Service Standard, Digital Transformation Agency
 - [Media Access Australia](http://www.mediaaccess.org.au/)
 - Online Style Guide, July 2011, Department of Communication and the Arts
-- [Online writing](https://www.dto.gov.au/standard/design-guides/online-writing/), Design guides, Digital Service Standard, Digital Transformation Office
+- [Online writing](https://www.dta.gov.au/standard/design-guides/online-writing/), Design guides, Digital Service Standard, Digital Transformation Agency
 - [Plain English Good Practice Guide ](http://publicsector.sa.gov.au/wp-content/uploads/20070101-Good-practice-guide-Plain-English.pdf), 2007, Government Reform Commission, Government of South Australia
 - [Plain English Manual, 776KB PDF](https://www.opc.gov.au/about/docs/Plain_English.pdf), Office of Parliamentary Counsel
-- Search engine optimisation, Design guides, Digital Service Standard, Digital Transformation Office
+- Search engine optimisation, Design guides, Digital Service Standard, Digital Transformation Agency
 - [Style guide, A to Z, GOV.UK](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style), Government Digital Service (GDS)
 - Style Guide for Australian Public Service Staff, 2012, Australian Public Service Commission
 - [Style manual for authors, editors and printers](http://www.australia.gov.au/about-government/publications/style-manual), 6th edition 2002, first published 1966, John Wiley and Sons Australia Ltd
@@ -54,4 +54,4 @@ The Draft Content Style Guide v1.0 has also been guided by these resources:
 - [Writing content for everyone, Government Digital Service Blog, GOV.UK](https://gds.blog.gov.uk/2016/02/23/writing-content-for-everyone/)
 - Writing Style Guide, November 2012, Australian Customs and Border Protection Service
 
-Read the [blog post about the thinking behind this Draft Content Style Guide](https://www.dto.gov.au/blog/walking-the-talk/).
+Read the [blog post about the thinking behind this Draft Content Style Guide](https://www.dta.gov.au/blog/walking-the-talk/).

--- a/_writing-for-the-web/2-optimise-your-content-for-search.md
+++ b/_writing-for-the-web/2-optimise-your-content-for-search.md
@@ -39,13 +39,13 @@ The description should:
 
 **For example**
 
-This description of the Digital Transformation Office’s website succinctly describes the agency’s key role in active voice.
+This description of the Digital Transformation Agency’s website succinctly describes the agency’s key role in active voice.
 
 ```
 <meta name="description" content="Driving the digital transformation of government information and services, making them simpler, clearer, faster.">
 ```
 
-![Digital Transformation Office search result](../images/dto-search.png)
+![Digital Transformation Agency search result](../images/dto-search.png)
 
 Caption: Meta title and description as they display in a search result.
 

--- a/_writing-for-the-web/4-pre-writing-checklist.md
+++ b/_writing-for-the-web/4-pre-writing-checklist.md
@@ -14,7 +14,7 @@ User needs can be functional or emotional --- we care about both. Sometimes they
 
 Content always needs to address the user's main needs so they can act on what we're asking them to do so they can solve their problem quickly and efficiently.
 
-In order to understand user needs it helps to actually meet users and observe in the real environment how they are currently solving the problem your information intends to improve. Read about the [Discovery stage](https://www.dto.gov.au/standard/service-design-and-delivery-process/discovery/).
+In order to understand user needs it helps to actually meet users and observe in the real environment how they are currently solving the problem your information intends to improve. Read about the [Discovery stage](https://www.dta.gov.au/standard/service-design-and-delivery-process/discovery/).
 
 ### What is the aim of the content?
 

--- a/_writing-for-the-web/5-think-like-a-content-designer.md
+++ b/_writing-for-the-web/5-think-like-a-content-designer.md
@@ -28,7 +28,7 @@ Our writing and editing skills are still critical, and play a strong role in the
 
 ### Embrace user research (the Discovery stage)
 
-The creation of good content ideally begins at [Discovery](https://www.dto.gov.au/standard/service-design-and-delivery-process/discovery/) at the very first user research session where the content designer takes on the role of observer.
+The creation of good content ideally begins at [Discovery](https://www.dta.gov.au/standard/service-design-and-delivery-process/discovery/) at the very first user research session where the content designer takes on the role of observer.
 
 The insights gained from listening and reflecting on what real people say, think and do in relation to the topics that we end up researching and writing about, is invaluable.
 
@@ -46,4 +46,4 @@ This is fantastic in that content people get to be part of the conversation and 
 
 And when it comes to the final stages of editing there is more efficiency and co-operation around our changes because we have been part of the conversations and ensuring consensus along the way.
 
-Learn more about [agile teams](https://www.dto.gov.au/standard/design-guides/the-team/).
+Learn more about [agile teams](https://www.dta.gov.au/standard/design-guides/the-team/).

--- a/az-guide.md
+++ b/az-guide.md
@@ -15,13 +15,13 @@ The content in this guide will be extended and new topics added based on your ne
 
 ## Who is it for?
 
-The guide is for all content creators and transformation teams working with the Digital Transformation Office.
+The guide is for all content creators and transformation teams working with the Digital Transformation Agency.
 
 We welcome this guide being adopted across government and hope that it is a starting point for further conversations, new content processes and ways to work together.
 
 ## Why is this guide being released as a draft?
 
-We believe that making things open makes them better. It’s one of the [Digital Transformation Office design principles](https://www.dto.gov.au/standard/design-principles/). We plan to test this draft version of the guide, incorporate feedback and iterate regularly.
+We believe that making things open makes them better. It’s one of the [Digital Transformation Agency design principles](https://www.dta.gov.au/standard/design-principles/). We plan to test this draft version of the guide, incorporate feedback and iterate regularly.
 
 ## Give feedback
 

--- a/guides/_posts/2016-05-05-optimise-your-content-for-search.md
+++ b/guides/_posts/2016-05-05-optimise-your-content-for-search.md
@@ -36,11 +36,11 @@ The description should:
 
 **For example**
 
-This description of the Digital Transformation Office’s website succinctly describes the agency’s key role in active voice.
+This description of the Digital Transformation Agency’s website succinctly describes the agency’s key role in active voice.
 
-<img of dc. metadata from dto.gov.au (that isn’t actually in the `head <meta>` section of the live site?) which should also be turned into `code` and not be an image?>
+<img of dc. metadata from dta.gov.au (that isn’t actually in the `head <meta>` section of the live site?) which should also be turned into `code` and not be an image?>
 
-<img screencap of the DTO metadata being used in the google search listing>
+<img screencap of the DTA metadata being used in the google search listing>
 
 Caption: Meta title and description as they display in a search result.
 

--- a/guides/_posts/2016-05-05-pre-writing-checklist.md
+++ b/guides/_posts/2016-05-05-pre-writing-checklist.md
@@ -9,7 +9,7 @@ published: true
 
 User needs can be functional or emotional (we care about both). Sometimes they’re created needs (created by things that the government needs them to do). Content always needs to address the user's main needs so they can act on what we're asking them to do so they can solve their problem quickly and efficiently.
 
-In order to understand user needs it helps to actually meet users and observe how they are currently solving the problem your information intends to improve within the right context. [Read about Discovery](https://www.dto.gov.au/standard/service-design-and-delivery-process/discovery/ "Read about Discovery")
+In order to understand user needs it helps to actually meet users and observe how they are currently solving the problem your information intends to improve within the right context. [Read about Discovery](https://www.dta.gov.au/standard/service-design-and-delivery-process/discovery/ "Read about Discovery")
 
 ## What is the aim of the content?
 

--- a/guides/_posts/2016-05-05-thing-like-a-govau-content-designer.md
+++ b/guides/_posts/2016-05-05-thing-like-a-govau-content-designer.md
@@ -27,7 +27,7 @@ Our writing and editing skills are still critical, and play a strong role in the
 
 ## Embrace the Discovery (research) phase
 
-The creation of good content ideally begins at [Discovery](https://www.dto.gov.au/standard/service-design-and-delivery-process/discovery/) at the very first user research session where the content designer takes on the role of observer.
+The creation of good content ideally begins at [Discovery](https://www.dta.gov.au/standard/service-design-and-delivery-process/discovery/) at the very first user research session where the content designer takes on the role of observer.
 
 The insights gained from listening and reflecting on what real people say, think and do in relation to the topic/s that we end up researching and writing about, is invaluable.
 
@@ -45,4 +45,4 @@ This is fantastic in that content people get to be part of the conversation and 
 
 And when it comes to the final stages of editing there is more efficiency and co-operation around our changes because we have been part of the conversations and ensuring consensus along the way.
 
-Learn more about [how we work](https://www.dto.gov.au/standard/design-guides/agile/ "Agile how we work").
+Learn more about [how we work](https://www.dta.gov.au/standard/design-guides/agile/ "Agile how we work").

--- a/index.md
+++ b/index.md
@@ -15,7 +15,7 @@ Please join our [Content Design in Government Google Group](https://groups.googl
 
 ## Who is it for?
 
-This guide is for all content creators and transformation teams working with the Digital Transformation Office.
+This guide is for all content creators and transformation teams working with the Digital Transformation Agency.
 
 We welcome this guide being adopted across government and hope that it is a starting point for new conversations and ways to work together.
 
@@ -23,7 +23,7 @@ We welcome this guide being adopted across government and hope that it is a star
 
 ## Why is this guide being released as a draft?
 
-We believe that making things open makes them better. It’s one of the [Digital Transformation Office design principles](https://www.dto.gov.au/standard/design-principles/). We plan to test this draft version of the guide, incorporate feedback and iterate regularly.
+We believe that making things open makes them better. It’s one of the [Digital Transformation Agency design principles](https://www.dta.gov.au/standard/design-principles/). We plan to test this draft version of the guide, incorporate feedback and iterate regularly.
 
 We are also iterating the platform code to support this and future work.
 
@@ -31,12 +31,12 @@ We are also iterating the platform code to support this and future work.
 
 ## How is this guide related to the Digital Service Standard?
 
-The [Digital Service Standard](https://www.dto.gov.au/standard/) requires teams to build services using a [style guide for online content](https://www.dto.gov.au/standard/6-consistent-and-responsive/). This is the first release of guidance that will eventually become the style guide for digital content.
+The [Digital Service Standard](https://www.dta.gov.au/standard/) requires teams to build services using a [style guide for online content](https://www.dta.gov.au/standard/6-consistent-and-responsive/). This is the first release of guidance that will eventually become the style guide for digital content.
 
-This and other [GOV.AU Guides](https://www.dto.gov.au/standard/design-guides/gov-au-guides/) will support the Digital Service Standard.
+This and other [GOV.AU Guides](https://www.dta.gov.au/standard/design-guides/gov-au-guides/) will support the Digital Service Standard.
 
 ***
 
 ## How was this guide put together?
 
-We asked our peers across government what they wanted in this guide. There were common themes: keep it up-to-date, make it easy to understand and give us examples. We were also guided by many expert sources. Read the blog on [how we put together the Content Style Guide](https://www.dto.gov.au/blog/walking-the-talk/).
+We asked our peers across government what they wanted in this guide. There were common themes: keep it up-to-date, make it easy to understand and give us examples. We were also guided by many expert sources. Read the blog on [how we put together the Content Style Guide](https://www.dta.gov.au/blog/walking-the-talk/).


### PR DESCRIPTION
## Description

* Change DTO to DTA and the longform of the same.
* Resolves https://github.com/AusDTO/gov-au-content-guide/issues/210 (though does not change repo name or any links to the repository from inside the repository - notably in changelog)

## Definition of Done

- [ ] Acceptance testing (for code changes - TBD)
- [ ] Draft reviewed by other Content Designer
- [ ] Update to [Updates page](http://content-style-guide.apps.staging.digital.gov.au/updates/)
- [ ] PR approved by Libby
- [ ] Related [GitHub issues](https://waffle.io/AusDTO/gov-au-content-guide) closed and cloud apps deleted
